### PR TITLE
💪 Retake `BaseRestfulApiContext.createAsync()` with `requested` at parameter

### DIFF
--- a/lib/server/restfulapi/contexts/BaseRestfulApiContext.js
+++ b/lib/server/restfulapi/contexts/BaseRestfulApiContext.js
@@ -67,17 +67,20 @@ export default class BaseRestfulApiContext {
   static async createAsync ({
     expressRequest,
     engine,
+    requestedAt = new Date(),
   }) {
     const userEntity = await this.findUser({
       expressRequest,
       accessToken: this.extractAccessToken({
         expressRequest,
       }),
+      requestedAt,
     })
     const visa = await this.createVisa({
       expressRequest,
       engine,
       userEntity,
+      requestedAt,
     })
 
     return this.create({
@@ -85,6 +88,7 @@ export default class BaseRestfulApiContext {
       engine,
       userEntity,
       visa,
+      requestedAt,
     })
   }
 
@@ -286,5 +290,6 @@ export default class BaseRestfulApiContext {
  * @typedef {{
  *   expressRequest: ExpressType.Request
  *   engine: RestfulApiType.ServerEngine
+ *   requestedAt?: Date
  * }} BaseRestfulApiContextAsyncFactoryParams
  */

--- a/tests/__tests__/server/restfulapi/contexts/BaseRestfulApiContext.js
+++ b/tests/__tests__/server/restfulapi/contexts/BaseRestfulApiContext.js
@@ -490,6 +490,7 @@ describe('BaseRestfulApiContext', () => {
             expressRequest: {
               path: '/alpha',
             },
+            requestedAt: new Date('2024-09-01T01:00:01.001Z'),
           },
           mocks: {
             userEntity: {
@@ -508,6 +509,7 @@ describe('BaseRestfulApiContext', () => {
             expressRequest: {
               path: '/beta',
             },
+            requestedAt: new Date('2024-09-02T02:00:02.002Z'),
           },
           mocks: {
             userEntity: {
@@ -529,15 +531,18 @@ describe('BaseRestfulApiContext', () => {
           engine: mockEngine,
           userEntity: mocks.userEntity,
           visa: mocks.visa,
+          requestedAt: params.requestedAt,
         }
         const expectedFindUserArgs = {
           expressRequest: params.expressRequest,
           accessToken: null,
+          requestedAt: params.requestedAt,
         }
         const expectedCreateVisaArgs = {
           expressRequest: params.expressRequest,
           engine: mockEngine,
           userEntity: mocks.userEntity,
+          requestedAt: params.requestedAt,
         }
 
         const createSpy = jest.spyOn(BaseRestfulApiContext, 'create')
@@ -549,6 +554,7 @@ describe('BaseRestfulApiContext', () => {
         const args = {
           expressRequest: params.expressRequest,
           engine: mockEngine,
+          requestedAt: params.requestedAt,
         }
 
         await BaseRestfulApiContext.createAsync(args)


### PR DESCRIPTION
# Why

* Close #27