### PR TITLE
🐛 Fix `BaseGraphqlServerEngine` to set `null` to `config.actualResolversPath`

### DIFF
--- a/lib/server/graphql/resolvers/GraphqlResolversBuilder.js
+++ b/lib/server/graphql/resolvers/GraphqlResolversBuilder.js
@@ -144,13 +144,17 @@ export default class GraphqlResolversBuilder {
    * Build resolver schema hash.
    *
    * @param {{
-   *   poolPath: string
+   *   poolPath: string | null
    * }} params - Parameters.
    * @returns {Promise<BuiltSchemaHash | null>} - Resolver schema hash.
    */
   static async buildResolverSchemaHash ({
     poolPath,
   }) {
+    if (!poolPath) {
+      return null
+    }
+
     const builder = await ResolverSchemaHashBuilder.createAsync({
       poolPath,
     })

--- a/tests/__tests__/server/graphql/resolvers/GraphqlResolversBuilder.js
+++ b/tests/__tests__/server/graphql/resolvers/GraphqlResolversBuilder.js
@@ -900,6 +900,19 @@ describe('GraphqlResolversBuilder', () => {
           .toEqual(expected)
       })
     })
+
+    describe('to be null', () => {
+      test('poolPath: null', async () => {
+        const args = {
+          poolPath: null,
+        }
+
+        const actual = await GraphqlResolversBuilder.buildResolverSchemaHash(args)
+
+        expect(actual)
+          .toBeNull()
+      })
+    })
   })
 })
 


### PR DESCRIPTION
# Why

* Close #73 
