### PR TITLE
⚒️ Retake `CreateChatRoomMutationResolver#resolve()` to handle on update chat rooms via `broker`

### DIFF
--- a/app/server/graphql/resolvers/customer/actual/mutations/CreateChatRoomMutationResolver.js
+++ b/app/server/graphql/resolvers/customer/actual/mutations/CreateChatRoomMutationResolver.js
@@ -1,6 +1,7 @@
 import ChatRoom from '../../../../../../sequelize/models/ChatRoom.js'
 
 import BaseMutationResolver from '../../../../../../../lib/server/graphql/resolvers/BaseMutationResolver.js'
+import OnUpdateChatRoomsSubscriptionResolver from '../subscriptions/OnUpdateChatRoomsSubscriptionResolver.js'
 
 export default class CreateChatRoomMutationResolver extends BaseMutationResolver {
   /** @override */
@@ -39,13 +40,47 @@ export default class CreateChatRoomMutationResolver extends BaseMutationResolver
         name,
       }))
 
-    rooms.sort((alpha, beta) =>
+    rooms.toSorted((alpha, beta) =>
       alpha.name.localeCompare(beta.name)
     )
+
+    await this.broadcastChatRooms({
+      context,
+      rooms,
+    })
 
     return {
       rooms,
     }
+  }
+
+  /**
+   * Broadcast notification.
+   *
+   * @param {{
+   *   context: GraphqlType.Context
+   *   rooms: Array<{
+   *     id: number
+   *     name: string
+   *   }>
+   * }} params - Parameters.
+   * @returns {Promise<void>} - Returns nothing.
+   */
+  broadcastChatRooms ({
+    context,
+    rooms,
+  }) {
+    const payload = {
+      rooms,
+    }
+    const topic = OnUpdateChatRoomsSubscriptionResolver.buildTopic({
+      payload,
+    })
+
+    return this.publishTopic({
+      context,
+      topic,
+    })
   }
 
   /**

--- a/app/server/graphql/resolvers/customer/actual/subscriptions/OnUpdateChatRoomsSubscriptionResolver.js
+++ b/app/server/graphql/resolvers/customer/actual/subscriptions/OnUpdateChatRoomsSubscriptionResolver.js
@@ -15,9 +15,7 @@ export default class OnUpdateChatRoomsSubscriptionResolver extends BaseSubscript
   generateChannelQuery ({
     context,
   }) {
-    return {
-      customerId: context.customerId,
-    }
+    return {}
   }
 }
 


### PR DESCRIPTION
# Why

* Close #114

# How

* Kick out unnecessary channel query from `OnUpdateChatRoomsSubscriptionResolver#generateChannelQuery()`
* Update `CreateChatRoomMutationResolver#resolve()` with `#broadcastChatRooms()`
