### PR TITLE
💪 Retake `BaseGraphqlContext.extractAccessToken()` with `.extractHeadersFromRequestParams()`

### DIFF
--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -121,9 +121,14 @@ export default class BaseGraphqlContext {
     expressRequest,
     requestParams,
   }) {
+    const resolvedHeaders = expressRequest.headers
+      ?? this.extractHeadersFromRequestParams({
+        requestParams,
+      })
+
     const headerKey = this.ACCESS_TOKEN_HEADER_KEY
 
-    return /** @type {*} */ (expressRequest.headers?.[headerKey])
+    return /** @type {*} */ (resolvedHeaders?.[headerKey])
       ?? null
   }
 

--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -107,11 +107,19 @@ export default class BaseGraphqlContext {
    *
    * @param {{
    *   expressRequest: ExpressType.Request
+   *   requestParams: GraphqlType.HttpRequestParams & {
+   *     payload?: {
+   *       context?: {
+   *         headers?: Record<string, string>
+   *       }
+   *     }
+   *   }
    * }} params - Parameters.
    * @returns {string | null} - Access token.
    */
   static extractAccessToken ({
     expressRequest,
+    requestParams,
   }) {
     const headerKey = this.ACCESS_TOKEN_HEADER_KEY
 

--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -153,7 +153,7 @@ export default class BaseGraphqlContext {
           headers,
         } = {},
       } = {},
-    },
+    } = {},
   }) {
     return headers ?? {}
   }

--- a/tests/__tests__/server/graphql/contexts/BaseGraphqlContext.js
+++ b/tests/__tests__/server/graphql/contexts/BaseGraphqlContext.js
@@ -595,42 +595,128 @@ describe('BaseGraphqlContext', () => {
 describe('BaseGraphqlContext', () => {
   describe('.extractAccessToken()', () => {
     describe('to return access token', () => {
-      /**
-       * @type {Array<{
-       *   params: {
-       *     expressRequest: ExpressType.Request
-       *   }
-       *   expected: string
-       * }>}
-       */
-      const cases = /** @type {*} */ ([
-        {
-          params: {
-            expressRequest: {
+      describe('from expressRequest', () => {
+        /**
+         * @type {GraphqlType.HttpRequestParams & {
+         *   payload?: {
+         *     context?: {
+         *       headers?: Record<string, string>
+         *     }
+         *   }
+         * }}
+         */
+        const requestParamsMock = /** @type {*} */ ({
+          payload: {
+            context: {
               headers: {
-                'x-renchan-access-token': 'alpha',
+                'x-renchan-access-token': 'omega',
               },
             },
           },
-          expected: 'alpha',
-        },
-        {
-          params: {
-            expressRequest: {
-              headers: {
-                'x-renchan-access-token': 'beta',
+        })
+
+        /**
+         * @type {Array<{
+         *   params: {
+         *     expressRequest: ExpressType.Request
+         *   }
+         *   expected: string
+         * }>}
+         */
+        const cases = /** @type {*} */ ([
+          {
+            params: {
+              expressRequest: {
+                headers: {
+                  'x-renchan-access-token': 'alpha',
+                },
               },
             },
+            expected: 'alpha',
           },
-          expected: 'beta',
-        },
-      ])
+          {
+            params: {
+              expressRequest: {
+                headers: {
+                  'x-renchan-access-token': 'beta',
+                },
+              },
+            },
+            expected: 'beta',
+          },
+        ])
 
-      test.each(cases)('x-renchan-access-token: $params.expressRequest.headers["x-renchan-access-token"]', ({ params, expected }) => {
-        const accessToken = BaseGraphqlContext.extractAccessToken(params)
+        test.each(cases)('x-renchan-access-token: $params.expressRequest.headers["x-renchan-access-token"]', ({ params, expected }) => {
+          const args = {
+            expressRequest: params.expressRequest,
+            requestParams: requestParamsMock,
+          }
+          const accessToken = BaseGraphqlContext.extractAccessToken(args)
 
-        expect(accessToken)
-          .toBe(expected)
+          expect(accessToken)
+            .toBe(expected)
+        })
+      })
+
+      describe('from requestParams', () => {
+        /** @type {ExpressType.Request} */
+        const expressRequestMock = /** @type {*} */ ({})
+
+        /**
+         * @type {Array<{
+         *   params: {
+         *     requestParams: GraphqlType.HttpRequestParams & {
+         *       payload?: {
+         *         context?: {
+         *           headers?: Record<string, string>
+         *         }
+         *       }
+         *     }
+         *   }
+         *   expected: string
+         * }>}
+         */
+        const cases = /** @type {*} */ ([
+          {
+            params: {
+              requestParams: {
+                payload: {
+                  context: {
+                    headers: {
+                      'x-renchan-access-token': 'alpha',
+                    },
+                  },
+                },
+              },
+            },
+            expected: 'alpha',
+          },
+          {
+            params: {
+              requestParams: {
+                payload: {
+                  context: {
+                    headers: {
+                      'x-renchan-access-token': 'beta',
+                    },
+                  },
+                },
+              },
+            },
+            expected: 'beta',
+          },
+        ])
+
+        test.each(cases)('x-renchan-access-token: $params.expressRequest.headers["x-renchan-access-token"]', ({ params, expected }) => {
+          const args = {
+            expressRequest: expressRequestMock,
+            requestParams: params.requestParams,
+          }
+          const accessToken = BaseGraphqlContext.extractAccessToken(args)
+
+          expect(accessToken)
+            .toBe(expected)
+        })
       })
     })
   })


### PR DESCRIPTION
# Why

* Close #171