### PR TITLE
🐛 Retake `BaseGraphqlContext.createAsync()` to call `.extractAccessToken()` with `requestParams`

### DIFF
--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -375,7 +375,13 @@ export default class BaseGraphqlContext {
 /**
  * @typedef {{
  *   expressRequest: ExpressType.Request
- *   requestParams: GraphqlType.HttpRequestParams
+ *   requestParams: GraphqlType.HttpRequestParams & {
+ *     payload?: {
+ *       context?: {
+ *         headers?: Record<string, string>
+ *       }
+ *     }
+ *   }
  *   engine: GraphqlType.ServerEngine
  *   requestedAt?: Date
  * }} BaseGraphqlContextAsyncFactoryParams

--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -74,6 +74,7 @@ export default class BaseGraphqlContext {
       expressRequest,
       accessToken: this.extractAccessToken({
         expressRequest,
+        requestParams,
       }),
       requestedAt,
     })

--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -70,12 +70,13 @@ export default class BaseGraphqlContext {
     engine,
     requestedAt = new Date(),
   }) {
+    const accessToken = this.extractAccessToken({
+      expressRequest,
+      requestParams,
+    })
     const userEntity = await this.findUser({
       expressRequest,
-      accessToken: this.extractAccessToken({
-        expressRequest,
-        requestParams,
-      }),
+      accessToken,
       requestedAt,
     })
     const visa = await this.createVisa({

--- a/tests/__tests__/server/graphql/contexts/BaseGraphqlContext.js
+++ b/tests/__tests__/server/graphql/contexts/BaseGraphqlContext.js
@@ -411,6 +411,15 @@ describe('BaseGraphqlContext', () => {
             expressRequest: {
               path: '/graphql-customer',
             },
+            requestParams: {
+              payload: {
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'alpha',
+                  },
+                },
+              },
+            },
             EngineCtor: CustomerGraphqlServerEngine,
           },
           mocks: {
@@ -428,6 +437,15 @@ describe('BaseGraphqlContext', () => {
           params: {
             expressRequest: {
               path: '/graphql-admin',
+            },
+            requestParams: {
+              payload: {
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'beta',
+                  },
+                },
+              },
             },
             EngineCtor: AdminGraphqlServerEngine,
           },
@@ -452,7 +470,7 @@ describe('BaseGraphqlContext', () => {
 
         const args = {
           expressRequest: params.expressRequest,
-          requestParams: null,
+          requestParams: params.requestParams,
           engine,
           requestedAt: new Date(),
         }
@@ -470,12 +488,9 @@ describe('BaseGraphqlContext', () => {
       /** @type {GraphqlType.ServerEngine} */
       const mockEngine = /** @type {*} */ ({})
 
-      /** @type {GraphqlType.HttpRequestParams} */
-      const mockExpressRequest = /** @type {*} */ ({})
-
       /**
        * @type {Array<{
-       *   params: import('../../../../../lib/server/graphql/contexts/BaseGraphqlContext.js').BaseGraphqlContextFactoryParams
+       *   params: import('../../../../../lib/server/graphql/contexts/BaseGraphqlContext.js').BaseGraphqlContextAsyncFactoryParams
        *   mocks: {
        *     userEntity: renchan.UserEntity
        *     visa: GraphqlType.Visa
@@ -487,6 +502,18 @@ describe('BaseGraphqlContext', () => {
           params: {
             expressRequest: {
               path: '/graphql-customer',
+              headers: {
+                'x-renchan-access-token': 'alpha',
+              },
+            },
+            requestParams: {
+              payload: {
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'omega',
+                  },
+                },
+              },
             },
             requestedAt: new Date('2024-11-01T01:00:01.001Z'),
           },
@@ -504,11 +531,23 @@ describe('BaseGraphqlContext', () => {
               },
             }),
           },
+          expected: {
+            accessToken: 'alpha',
+          },
         },
         {
           params: {
             expressRequest: {
               path: '/graphql-admin',
+            },
+            requestParams: {
+              payload: {
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'beta',
+                  },
+                },
+              },
             },
             requestedAt: new Date('2024-11-02T02:00:02.002Z'),
           },
@@ -526,10 +565,13 @@ describe('BaseGraphqlContext', () => {
               },
             }),
           },
+          expected: {
+            accessToken: 'beta',
+          },
         },
       ])
 
-      test.each(cases)('path: $params.expressRequest.path', async ({ params, mocks }) => {
+      test.each(cases)('path: $params.expressRequest.path', async ({ params, mocks, expected }) => {
         const expectedCreateArgs = {
           expressRequest: params.expressRequest,
           engine: mockEngine,
@@ -537,9 +579,13 @@ describe('BaseGraphqlContext', () => {
           visa: mocks.visa,
           requestedAt: params.requestedAt,
         }
+        const expectedExtractAccessTokenArgs = {
+          expressRequest: params.expressRequest,
+          requestParams: params.requestParams,
+        }
         const expectedFindUserArgs = {
           expressRequest: params.expressRequest,
-          accessToken: null,
+          accessToken: expected.accessToken,
           requestedAt: params.requestedAt,
         }
         const expectedCreateVisaArgs = {
@@ -550,6 +596,7 @@ describe('BaseGraphqlContext', () => {
         }
 
         const createSpy = jest.spyOn(BaseGraphqlContext, 'create')
+        const extractAccessTokenSpy = jest.spyOn(BaseGraphqlContext, 'extractAccessToken')
         const findUserSpy = jest.spyOn(BaseGraphqlContext, 'findUser')
           .mockResolvedValue(mocks.userEntity)
         const createVisaSpy = jest.spyOn(BaseGraphqlContext, 'createVisa')
@@ -557,7 +604,7 @@ describe('BaseGraphqlContext', () => {
 
         const args = {
           expressRequest: params.expressRequest,
-          requestParams: mockExpressRequest,
+          requestParams: params.requestParams,
           engine: mockEngine,
           requestedAt: params.requestedAt,
         }
@@ -566,6 +613,8 @@ describe('BaseGraphqlContext', () => {
 
         expect(createSpy)
           .toHaveBeenCalledWith(expectedCreateArgs)
+        expect(extractAccessTokenSpy)
+          .toHaveBeenCalledWith(expectedExtractAccessTokenArgs)
         expect(findUserSpy)
           .toHaveBeenCalledWith(expectedFindUserArgs)
         expect(createVisaSpy)


### PR DESCRIPTION
# Why

* Close #175