### PR TITLE
💪 Retake `BaseGraphqlContext.create()` to handle `requestParams`

### DIFF
--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -363,6 +363,7 @@ export default class BaseGraphqlContext {
 /**
  * @typedef {{
  *   expressRequest: ExpressType.Request
+ *   requestParams: ResolvedRequestParams
  *   userEntity: renchan.UserEntity | null
  *   engine: GraphqlType.ServerEngine
  *   visa: GraphqlType.Visa

--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -40,6 +40,7 @@ export default class BaseGraphqlContext {
    */
   static create ({
     expressRequest,
+    requestParams,
     engine,
     userEntity,
     visa,
@@ -49,6 +50,7 @@ export default class BaseGraphqlContext {
     return /** @type {InstanceType<T>} */ (
       new this({
         expressRequest,
+        requestParams,
         engine,
         userEntity,
         visa,

--- a/tests/__tests__/server/graphql/contexts/BaseGraphqlContext.js
+++ b/tests/__tests__/server/graphql/contexts/BaseGraphqlContext.js
@@ -405,6 +405,15 @@ describe('BaseGraphqlContext', () => {
 
 describe('BaseGraphqlContext', () => {
   describe('.create()', () => {
+    const queryMock = `
+      subscription OnObserveChatStates ($input: OnObserveChatStatesInput!) {
+        onObserveChatStates (input: $input) {
+          hasUnreadMessages
+          isUpdatedMembers
+        }
+      }
+    `
+
     /** @type {renchan.UserEntity} */
     const mockUser = /** @type {*} */ ({})
 
@@ -423,6 +432,21 @@ describe('BaseGraphqlContext', () => {
             expressRequest: {
               path: '/graphql-customer',
             },
+            requestParams: {
+              id: '98765432-abcd-0000-1234-000000000001',
+              type: 'subscribe',
+              payload: {
+                query: queryMock,
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'alpha',
+                  },
+                },
+                variables: {
+                  roomId: 100001,
+                },
+              },
+            },
             userEntity: mockUser,
             visa: mockVisa,
           },
@@ -431,6 +455,21 @@ describe('BaseGraphqlContext', () => {
           params: {
             expressRequest: {
               path: '/graphql-admin',
+            },
+            requestParams: {
+              id: '98765432-abcd-0000-1234-000000000002',
+              type: 'subscribe',
+              payload: {
+                query: queryMock,
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'beta',
+                  },
+                },
+                variables: {
+                  roomId: 100002,
+                },
+              },
             },
             userEntity: mockUser,
             visa: mockVisa,
@@ -458,6 +497,21 @@ describe('BaseGraphqlContext', () => {
             expressRequest: {
               path: '/graphql-customer',
             },
+            requestParams: {
+              id: '98765432-abcd-0000-1234-000000000001',
+              type: 'subscribe',
+              payload: {
+                query: queryMock,
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'alpha',
+                  },
+                },
+                variables: {
+                  roomId: 100001,
+                },
+              },
+            },
             engine: null,
             userEntity: mockUser,
             visa: mockVisa,
@@ -469,6 +523,21 @@ describe('BaseGraphqlContext', () => {
           params: {
             expressRequest: {
               path: '/graphql-admin',
+            },
+            requestParams: {
+              id: '98765432-abcd-0000-1234-000000000002',
+              type: 'subscribe',
+              payload: {
+                query: queryMock,
+                context: {
+                  headers: {
+                    'x-renchan-access-token': 'beta',
+                  },
+                },
+                variables: {
+                  roomId: 100002,
+                },
+              },
             },
             engine: null,
             userEntity: mockUser,


### PR DESCRIPTION
# Why

* Close #184