### PR TITLE
🧩 Retake JSDoc of `BaseGraphqlContext.extractHeadersFromRequestParams()`

### DIFF
--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -137,13 +137,7 @@ export default class BaseGraphqlContext {
    * Extract headers from request params.
    *
    * @param {{
-   *   requestParams: {
-   *     payload?: {
-   *       context?: {
-   *         headers?: Record<string, string>
-   *       }
-   *     }
-   *   }
+   *   requestParams: ResolvedRequestParams
    * }} params - Parameters.
    * @returns {Record<string, string>} - Headers.
    */

--- a/lib/server/graphql/contexts/BaseGraphqlContext.js
+++ b/lib/server/graphql/contexts/BaseGraphqlContext.js
@@ -142,15 +142,12 @@ export default class BaseGraphqlContext {
    * @returns {Record<string, string>} - Headers.
    */
   static extractHeadersFromRequestParams ({
-    requestParams: {
-      payload: {
-        context: {
-          headers,
-        } = {},
-      } = {},
-    } = {},
+    requestParams,
   }) {
-    return headers ?? {}
+    return /** @type {GraphqlType.WebSocketRequestParams} */ (requestParams).payload
+      ?.context
+      ?.headers
+      ?? {}
   }
 
   /**


### PR DESCRIPTION
# Why

* Close #191
