### PR TITLE
🦵 Kick out `customerId` from `SendChatMessageMutationResolver#resolve()`

### DIFF
--- a/app/server/graphql/resolvers/customer/actual/mutations/SendChatMessageMutationResolver.js
+++ b/app/server/graphql/resolvers/customer/actual/mutations/SendChatMessageMutationResolver.js
@@ -23,15 +23,16 @@ export default class SendChatMessageMutationResolver extends BaseMutationResolve
     variables: {
       input: {
         chatRoomId,
-        customerId,
         content,
       },
     },
     context,
   }) {
+    const authenticatedCustomerId = context.customerId
+
     const attributeHash = {
       ChatRoomId: chatRoomId,
-      CustomerId: customerId,
+      CustomerId: authenticatedCustomerId,
       content,
       postedAt: context.now,
     }
@@ -49,8 +50,9 @@ export default class SendChatMessageMutationResolver extends BaseMutationResolve
 
     const message = {
       id: result.id,
+      postedAt: context.now,
       content,
-      sender: `[${customerId}]`,
+      sender: `[${authenticatedCustomerId}]`,
     }
 
     await this.broadcastChatMessage({

--- a/app/server/graphql/schemas/customer-subscription.graphql
+++ b/app/server/graphql/schemas/customer-subscription.graphql
@@ -312,7 +312,6 @@ input CreateChatRoomInput {
 
 input SendChatMessageInput {
   chatRoomId: Int!
-  customerId: Int!
   content: String!
 }
 


### PR DESCRIPTION
# Why

* Close #210
