### PR TITLE
🧹 Rename `GraphqlPostWorkerHashBuilder#buildPostWorkersHash()` to `#buildPostWorkerHash()`

### DIFF
--- a/lib/server/graphql/post-workers/GraphqlPostWorkerHashBuilder.js
+++ b/lib/server/graphql/post-workers/GraphqlPostWorkerHashBuilder.js
@@ -97,7 +97,7 @@ export default class GraphqlPostWorkerHashBuilder {
    * @returns {Record<string, GraphqlType.PostWorker>} - Post worker hash.
    * @public
    */
-  buildPostWorkersHash () {
+  buildPostWorkerHash () {
     return Object.fromEntries(
       this.postWorkers.map(
         it => [

--- a/tests/__tests__/server/graphql/post-workers/GraphqlPostWorkerHashBuilder.js
+++ b/tests/__tests__/server/graphql/post-workers/GraphqlPostWorkerHashBuilder.js
@@ -447,7 +447,7 @@ describe('GraphqlPostWorkerHashBuilder', () => {
 })
 
 describe('GraphqlPostWorkerHashBuilder', () => {
-  describe('#buildResolverHash()', () => {
+  describe('#buildPostWorkerHash()', () => {
     const AlphaServerEngine = class extends BaseGraphqlServerEngine {}
     const BetaServerEngine = class extends BaseGraphqlServerEngine {}
 
@@ -518,7 +518,7 @@ describe('GraphqlPostWorkerHashBuilder', () => {
         engine,
       })
 
-      const actual = builder.buildPostWorkersHash()
+      const actual = builder.buildPostWorkerHash()
 
       expect(actual)
         .toEqual(expected)


### PR DESCRIPTION
# Why

* Close #305
