### PR TITLE
🦵 Kick out unnecessary `jest/max-nested-describe` ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,15 +53,4 @@ export default [
       'jsdoc/valid-types': 'off',
     },
   },
-
-  {
-    rules: {
-      'jest/max-nested-describe': [
-        'error',
-        {
-          max: 6, // 5
-        },
-      ],
-    },
-  },
 ]


### PR DESCRIPTION
# Why

* Close #342