### PR TITLE
💪 Udpate `GraphqlHttpHandlerBuilder#buildHandler()` with `Express` request based porter structure

### DIFF
--- a/lib/server/graphql/GraphqlHttpHandlerBuilder.js
+++ b/lib/server/graphql/GraphqlHttpHandlerBuilder.js
@@ -287,13 +287,34 @@ export default class GraphqlHttpHandlerBuilder {
    * @public
    */
   buildHandler () {
-    return createHandler({
-      schema: this.schema,
+    const schemaWithMiddleware = this.generateInterceptedSchema()
+
+    const graphqlHandler = this.Ctor.createHandler({
+      schema: schemaWithMiddleware,
       context: this.context,
       rootValue: this.rootValue,
       formatError: this.formatError,
       validationRules: this.validationRules,
     })
+
+    return async (
+      req,
+      res,
+      next
+    ) => {
+      res.on(
+        'finish',
+        this.defineOnFinishHandler({
+          expressRequest: req,
+        })
+      )
+
+      await graphqlHandler(
+        req,
+        res,
+        next
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
# Why

* Close #304