### PR TITLE
💪 Retake `RestfulApiRequest.create()` with `.createPashParameterHashProxy()`

### DIFF
--- a/lib/server/restfulapi/interfaces/RestfulApiRequest.js
+++ b/lib/server/restfulapi/interfaces/RestfulApiRequest.js
@@ -26,9 +26,14 @@ export default class RestfulApiRequest {
   static create ({
     expressRequest,
   }) {
+    const pathParameterHashProxy = this.createPashParameterHashProxy({
+      expressRequest,
+    })
+
     return /** @type {InstanceType<T>} */ (
       new this({
         expressRequest,
+        pathParameterHashProxy,
       })
     )
   }

--- a/tests/__tests__/server/restfulapi/RestfulApiRoutesBuilder.js
+++ b/tests/__tests__/server/restfulapi/RestfulApiRoutesBuilder.js
@@ -887,6 +887,7 @@ describe('RestfulApiRoutesBuilder', () => {
     describe('generated handler', () => {
       /** @type {ExpressType.Request} */
       const expressRequestTally = /** @type {*} */ ({
+        params: {},
         tally: Symbol('express request tally'),
       })
 
@@ -976,6 +977,7 @@ describe('RestfulApiRoutesBuilder', () => {
               expressRequest: /** @type {*} */ ({
                 body: Symbol('get tally'),
                 query: Symbol('post tally'),
+                params: {},
               }),
             })
 
@@ -1024,6 +1026,7 @@ describe('RestfulApiRoutesBuilder', () => {
               expressRequest: /** @type {*} */ ({
                 body: Symbol('get tally'),
                 query: Symbol('post tally'),
+                params: {},
               }),
             })
 
@@ -1281,6 +1284,7 @@ describe('RestfulApiRoutesBuilder', () => {
         query: {
           tally: Symbol('post tally'),
         },
+        params: {},
       })
 
       const builder = await RestfulApiRoutesBuilder.createAsync({
@@ -1334,7 +1338,9 @@ describe('RestfulApiRoutesBuilder', () => {
         })
 
         const actual = builder.createRestfulApiRequest({
-          expressRequest: /** @type {*} */ ({}),
+          expressRequest: /** @type {*} */ ({
+            params: {},
+          }),
         })
 
         expect(actual)

--- a/tests/__tests__/server/restfulapi/interfaces/RestfulApiRequest.js
+++ b/tests/__tests__/server/restfulapi/interfaces/RestfulApiRequest.js
@@ -193,6 +193,7 @@ describe('RestfulApiRequest', () => {
             headers: {
               beta: Symbol.for('beta-value'),
             },
+            params: {},
           },
         },
         expected: {

--- a/tests/__tests__/server/restfulapi/interfaces/RestfulApiRequest.js
+++ b/tests/__tests__/server/restfulapi/interfaces/RestfulApiRequest.js
@@ -164,56 +164,6 @@ describe('RestfulApiRequest', () => {
 })
 
 describe('RestfulApiRequest', () => {
-  describe('.get:headers', () => {
-    /**
-     * @type {Array<{
-     *   params: {
-     *     expressRequest: ExpressType.Request
-     *   }
-     *   expected: Headers
-     * }>}
-     */
-    const cases = /** @type {*} */ ([
-      {
-        params: {
-          expressRequest: {
-            headers: {
-              alpha: Symbol.for('alpha-value'),
-            },
-            params: {},
-          },
-        },
-        expected: {
-          alpha: Symbol.for('alpha-value'),
-        },
-      },
-      {
-        params: {
-          expressRequest: {
-            headers: {
-              beta: Symbol.for('beta-value'),
-            },
-            params: {},
-          },
-        },
-        expected: {
-          beta: Symbol.for('beta-value'),
-        },
-      },
-    ])
-
-    test.each(cases)('expressRequest: $params.expressRequest', ({ params, expected }) => {
-      const request = RestfulApiRequest.create(params)
-
-      const actual = request.headers
-
-      expect(actual)
-        .toEqual(expected)
-    })
-  })
-})
-
-describe('RestfulApiRequest', () => {
   describe('.createPashParameterHashProxy()', () => {
     describe('with existing parameter', () => {
       /**
@@ -335,6 +285,56 @@ describe('RestfulApiRequest', () => {
             .toBeNull()
         })
       })
+    })
+  })
+})
+
+describe('RestfulApiRequest', () => {
+  describe('#get:headers', () => {
+    /**
+     * @type {Array<{
+     *   params: {
+     *     expressRequest: ExpressType.Request
+     *   }
+     *   expected: Headers
+     * }>}
+     */
+    const cases = /** @type {*} */ ([
+      {
+        params: {
+          expressRequest: {
+            headers: {
+              alpha: Symbol.for('alpha-value'),
+            },
+            params: {},
+          },
+        },
+        expected: {
+          alpha: Symbol.for('alpha-value'),
+        },
+      },
+      {
+        params: {
+          expressRequest: {
+            headers: {
+              beta: Symbol.for('beta-value'),
+            },
+            params: {},
+          },
+        },
+        expected: {
+          beta: Symbol.for('beta-value'),
+        },
+      },
+    ])
+
+    test.each(cases)('expressRequest: $params.expressRequest', ({ params, expected }) => {
+      const request = RestfulApiRequest.create(params)
+
+      const actual = request.headers
+
+      expect(actual)
+        .toEqual(expected)
     })
   })
 })

--- a/tests/__tests__/server/restfulapi/interfaces/RestfulApiRequest.js
+++ b/tests/__tests__/server/restfulapi/interfaces/RestfulApiRequest.js
@@ -109,6 +109,7 @@ describe('RestfulApiRequest', () => {
             query: {
               alpha: 1,
             },
+            params: {},
           },
         },
       },
@@ -118,6 +119,7 @@ describe('RestfulApiRequest', () => {
             query: {
               beta: 2,
             },
+            params: {},
           },
         },
       },
@@ -125,21 +127,37 @@ describe('RestfulApiRequest', () => {
 
     describe('to be instance of own class', () => {
       test.each(cases)('expressRequest: $params.expressRequest', ({ params }) => {
-        const error = RestfulApiRequest.create(params)
+        const request = RestfulApiRequest.create(params)
 
-        expect(error)
+        expect(request)
           .toBeInstanceOf(RestfulApiRequest)
       })
     })
 
     describe('to call constructor', () => {
       test.each(cases)('expressRequest: $params.expressRequest', ({ params }) => {
+        /** @type {ExpressType.Request['params']} */
+        const pathParameterHashProxyTally = new Proxy({}, {})
+
+        const expectedConstructorArgs = {
+          expressRequest: params.expressRequest,
+          pathParameterHashProxy: pathParameterHashProxyTally,
+        }
+        const expectedFactoryArgs = {
+          expressRequest: params.expressRequest,
+        }
+
+        const createPashParameterHashProxySpy = jest.spyOn(RestfulApiRequest, 'createPashParameterHashProxy')
+          .mockReturnValue(pathParameterHashProxyTally)
+
         const SpyClass = globalThis.constructorSpy.spyOn(RestfulApiRequest)
 
         SpyClass.create(params)
 
         expect(SpyClass.__spy__)
-          .toHaveBeenCalledWith(params)
+          .toHaveBeenCalledWith(expectedConstructorArgs)
+        expect(createPashParameterHashProxySpy)
+          .toHaveBeenCalledWith(expectedFactoryArgs)
       })
     })
   })
@@ -162,6 +180,7 @@ describe('RestfulApiRequest', () => {
             headers: {
               alpha: Symbol.for('alpha-value'),
             },
+            params: {},
           },
         },
         expected: {


### PR DESCRIPTION
# Why

* Close #431
