### PR TITLE
⚒️ Define `BaseRenderer.get:preExpressHandlers`

### DIFF
--- a/lib/server/restfulapi/renderers/BaseRenderer.js
+++ b/lib/server/restfulapi/renderers/BaseRenderer.js
@@ -156,6 +156,15 @@ export default class BaseRenderer {
   }
 
   /**
+   * get: Pre-Express handlers.
+   *
+   * @returns {Array<ExpressType.Middleware>} - Pre-Express handlers.
+   */
+  static get preExpressHandlers () {
+    return []
+  }
+
+  /**
    * get: Flusher constructor.
    *
    * @returns {RestfulApiType.ResponseFlusherCtor} - Flusher constructor.

--- a/tests/__tests__/server/restfulapi/renderers/BaseRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BaseRenderer.js
@@ -325,6 +325,21 @@ describe('BaseRenderer', () => {
 })
 
 describe('BaseRenderer', () => {
+  describe('.get:preExpressHandlers', () => {
+    describe('to be fixed value', () => {
+      test('as default value', () => {
+        const expected = []
+
+        const actual = BaseRenderer.preExpressHandlers
+
+        expect(actual)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('BaseRenderer', () => {
   describe('.get:FlusherCtor', () => {
     describe('to be fixed value', () => {
       test('as default value', () => {


### PR DESCRIPTION
# Why

* Close #477