### PR TITLE
🧹 Change `preExpressHandlers` getter to `buildPreExpressHandlers()` method in `Renderer` family

### DIFF
--- a/lib/server/restfulapi/RestfulApiRoutesBuilder.js
+++ b/lib/server/restfulapi/RestfulApiRoutesBuilder.js
@@ -156,7 +156,7 @@ export default class RestfulApiRoutesBuilder {
           method: it.method,
           path: fullPath,
           handlers: [
-            ...it.preExpressHandlers,
+            ...it.buildPreExpressHandlers(),
 
             renderHandler,
           ],

--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -22,11 +22,11 @@ export default class BasePostRenderer extends BaseRenderer {
   }
 
   /**
-   * get: Pre-Express handlers.
+   * Build pre-Express handlers.
    *
-   * @returns {Array<ExpressType.Middleware>} - Pre-Express handlers.
+   * @returns {Array<ExpressType.Middleware>} Pre-Express handlers.
    */
-  static get preExpressHandlers () {
+  static buildPreExpressHandlers () {
     const multerUploader = this.createMulterUploader()
 
     return [

--- a/lib/server/restfulapi/renderers/BaseRenderer.js
+++ b/lib/server/restfulapi/renderers/BaseRenderer.js
@@ -222,12 +222,12 @@ export default class BaseRenderer {
   }
 
   /**
-   * get: Pre-Express handlers.
+   * Build pre-Express handlers.
    *
    * @returns {Array<ExpressType.Middleware>} - Pre-Express handlers.
    */
-  get preExpressHandlers () {
-    return this.Ctor.preExpressHandlers
+  buildPreExpressHandlers () {
+    return this.Ctor.buildPreExpressHandlers()
   }
 
   /**

--- a/lib/server/restfulapi/renderers/BaseRenderer.js
+++ b/lib/server/restfulapi/renderers/BaseRenderer.js
@@ -156,11 +156,11 @@ export default class BaseRenderer {
   }
 
   /**
-   * get: Pre-Express handlers.
+   * Build pre-Express handlers.
    *
    * @returns {Array<ExpressType.Middleware>} - Pre-Express handlers.
    */
-  static get preExpressHandlers () {
+  static buildPreExpressHandlers () {
     return []
   }
 

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -29,7 +29,7 @@ describe('BasePostRenderer', () => {
 })
 
 describe('BasePostRenderer', () => {
-  describe('.get:preExpressHandlers', () => {
+  describe('.buildPreExpressHandlers()', () => {
     test('should be an instance of Multer', () => {
       const multerUploaderTally = multer()
       const handlerTally = () => {}
@@ -44,7 +44,7 @@ describe('BasePostRenderer', () => {
       const noneSpy = jest.spyOn(multerUploaderTally, 'none')
         .mockReturnValue(handlerTally)
 
-      const actual = BasePostRenderer.preExpressHandlers
+      const actual = BasePostRenderer.buildPreExpressHandlers()
 
       expect(actual)
         .toEqual(expected)

--- a/tests/__tests__/server/restfulapi/renderers/BaseRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BaseRenderer.js
@@ -594,7 +594,7 @@ describe('BaseRenderer', () => {
 })
 
 describe('BaseRenderer', () => {
-  describe('#get:preExpressHandlers', () => {
+  describe('#buildPreExpressHandlers()', () => {
     describe('to fixed value', () => {
       const cases = [
         {
@@ -637,14 +637,14 @@ describe('BaseRenderer', () => {
 
       test.each(cases)('errorStructureHash: $params.errorStructureHash', ({ params }) => {
         const expected = []
-        const tally = BaseRenderer.preExpressHandlers
+        const tally = BaseRenderer.buildPreExpressHandlers()
 
         const args = {
           errorStructureHash: params.errorStructureHash,
         }
         const renderer = BaseRenderer.create(args)
 
-        const actual = renderer.preExpressHandlers
+        const actual = renderer.buildPreExpressHandlers()
 
         expect(actual)
           .toEqual(expected)

--- a/tests/__tests__/server/restfulapi/renderers/BaseRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BaseRenderer.js
@@ -325,12 +325,12 @@ describe('BaseRenderer', () => {
 })
 
 describe('BaseRenderer', () => {
-  describe('.get:preExpressHandlers', () => {
+  describe('.buildPreExpressHandlers()', () => {
     describe('to be fixed value', () => {
       test('as default value', () => {
         const expected = []
 
-        const actual = BaseRenderer.preExpressHandlers
+        const actual = BaseRenderer.buildPreExpressHandlers()
 
         expect(actual)
           .toEqual(expected)


### PR DESCRIPTION
# Why

* Close #494
