### PR TITLE
💪 Retake `BasePostRenderer.buildPreExpressHandlers()` with `BaseRenderer.buildPreExpressHandlers()`

### DIFF
--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -30,6 +30,8 @@ export default class BasePostRenderer extends BaseRenderer {
     const multerUploader = this.createMulterUploader()
 
     return [
+      ...super.buildPreExpressHandlers(),
+
       multerUploader.none(), // for multipart/form-data
     ]
   }

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -40,6 +40,7 @@ describe('BasePostRenderer', () => {
 
       const createMulterUploaderSpy = jest.spyOn(BasePostRenderer, 'createMulterUploader')
         .mockReturnValue(multerUploaderTally)
+      const buildPreExpressHandlersSpy = jest.spyOn(BaseRenderer, 'buildPreExpressHandlers')
 
       const noneSpy = jest.spyOn(multerUploaderTally, 'none')
         .mockReturnValue(handlerTally)
@@ -50,6 +51,8 @@ describe('BasePostRenderer', () => {
         .toEqual(expected)
 
       expect(createMulterUploaderSpy)
+        .toHaveBeenCalledWith()
+      expect(buildPreExpressHandlersSpy)
         .toHaveBeenCalledWith()
       expect(noneSpy)
         .toHaveBeenCalledWith()


### PR DESCRIPTION
# Why

* Close #496