### PR TITLE
💪 Retake `BasePostRender.buildPreExpressHandlers()` with `.defineMulterUploaderMiddleware()`

### DIFF
--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -27,12 +27,10 @@ export default class BasePostRenderer extends BaseRenderer {
    * @returns {Array<ExpressType.Middleware>} Pre-Express handlers.
    */
   static buildPreExpressHandlers () {
-    const multerUploader = this.createMulterUploader()
-
     return [
       ...super.buildPreExpressHandlers(),
 
-      multerUploader.none(), // for multipart/form-data
+      this.defineMulterUploaderMiddleware(), // on Content-Type: multipart/form-data
     ]
   }
 

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -31,30 +31,24 @@ describe('BasePostRenderer', () => {
 describe('BasePostRenderer', () => {
   describe('.buildPreExpressHandlers()', () => {
     test('should be an instance of Multer', () => {
-      const multerUploaderTally = multer()
-      const handlerTally = () => {}
+      const middlewareTally = () => {}
 
       const expected = [
-        handlerTally,
+        middlewareTally,
       ]
 
-      const createMulterUploaderSpy = jest.spyOn(BasePostRenderer, 'createMulterUploader')
-        .mockReturnValue(multerUploaderTally)
+      const defineMulterUploaderMiddlewareSpy = jest.spyOn(BasePostRenderer, 'defineMulterUploaderMiddleware')
+        .mockReturnValue(middlewareTally)
       const buildPreExpressHandlersSpy = jest.spyOn(BaseRenderer, 'buildPreExpressHandlers')
-
-      const noneSpy = jest.spyOn(multerUploaderTally, 'none')
-        .mockReturnValue(handlerTally)
 
       const actual = BasePostRenderer.buildPreExpressHandlers()
 
       expect(actual)
         .toEqual(expected)
 
-      expect(createMulterUploaderSpy)
+      expect(defineMulterUploaderMiddlewareSpy)
         .toHaveBeenCalledWith()
       expect(buildPreExpressHandlersSpy)
-        .toHaveBeenCalledWith()
-      expect(noneSpy)
         .toHaveBeenCalledWith()
     })
   })


### PR DESCRIPTION
# Why

* Close #505