### PR TITLE
✅️ Enchane `BasePostRenderer.buildPreExpressHandlers()` with `fileFieldsConfigHash`

### DIFF
--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -27,12 +27,10 @@ export default class BasePostRenderer extends BaseRenderer {
    * @returns {Array<ExpressType.Middleware>} Pre-Express handlers.
    */
   static buildPreExpressHandlers () {
-    const multerUploader = this.createMulterUploader()
-
     return [
       ...super.buildPreExpressHandlers(),
 
-      multerUploader.none(), // for multipart/form-data
+      this.defineMulterUploaderMiddleware(), // on Content-Type: multipart/form-data
     ]
   }
 

--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -55,6 +55,22 @@ export default class BasePostRenderer extends BaseRenderer {
   }
 
   /**
+   * Build Multer uploader fields input.
+   *
+   * @returns {Array<{
+   *   name: string
+   *   maxCount: number
+   * }>} - Multer uploader fields input.
+   */
+  static buildMulterUploaderFieldsInput () {
+    return Object.entries(this.fileFieldsConfigHash)
+      .map(([name, maxCount]) => ({
+        name,
+        maxCount,
+      }))
+  }
+
+  /**
    * get: File fields config hash of Multer uploader.
    *
    * @abstract

--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -37,6 +37,23 @@ export default class BasePostRenderer extends BaseRenderer {
   }
 
   /**
+   * Define Multer uploader Express handler.
+   *
+   * @returns {ExpressType.Middleware} - Multer uploader handler.
+   */
+  static defineMulterUploaderMiddleware () {
+    const multerUploader = this.createMulterUploader()
+
+    const multerUploaderFieldsInput = this.buildMulterUploaderFieldsInput()
+
+    if (multerUploaderFieldsInput.length === 0) {
+      return multerUploader.none() // no file upload
+    }
+
+    return multerUploader.fields(multerUploaderFieldsInput)
+  }
+
+  /**
    * get: Multer instance.
    *
    * @returns {multer.Multer} - Multer instance.

--- a/lib/server/restfulapi/renderers/BasePostRenderer.js
+++ b/lib/server/restfulapi/renderers/BasePostRenderer.js
@@ -53,4 +53,16 @@ export default class BasePostRenderer extends BaseRenderer {
   static get multer () {
     return multer
   }
+
+  /**
+   * get: File fields config hash of Multer uploader.
+   *
+   * @abstract
+   * @returns {{
+   *   [name: string]: number // maxCount of files for this field.
+   * }} - Multer uploader fields config.
+   */
+  static get fileFieldsConfigHash () {
+    return {}
+  }
 }

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -31,30 +31,24 @@ describe('BasePostRenderer', () => {
 describe('BasePostRenderer', () => {
   describe('.buildPreExpressHandlers()', () => {
     test('should be an instance of Multer', () => {
-      const multerUploaderTally = multer()
-      const handlerTally = () => {}
+      const middlewareTally = () => {}
 
       const expected = [
-        handlerTally,
+        middlewareTally,
       ]
 
-      const createMulterUploaderSpy = jest.spyOn(BasePostRenderer, 'createMulterUploader')
-        .mockReturnValue(multerUploaderTally)
+      const defineMulterUploaderMiddlewareSpy = jest.spyOn(BasePostRenderer, 'defineMulterUploaderMiddleware')
+        .mockReturnValue(middlewareTally)
       const buildPreExpressHandlersSpy = jest.spyOn(BaseRenderer, 'buildPreExpressHandlers')
-
-      const noneSpy = jest.spyOn(multerUploaderTally, 'none')
-        .mockReturnValue(handlerTally)
 
       const actual = BasePostRenderer.buildPreExpressHandlers()
 
       expect(actual)
         .toEqual(expected)
 
-      expect(createMulterUploaderSpy)
+      expect(defineMulterUploaderMiddlewareSpy)
         .toHaveBeenCalledWith()
       expect(buildPreExpressHandlersSpy)
-        .toHaveBeenCalledWith()
-      expect(noneSpy)
         .toHaveBeenCalledWith()
     })
   })

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -97,3 +97,16 @@ describe('BasePostRenderer', () => {
     })
   })
 })
+
+describe('BasePostRenderer', () => {
+  describe('.get:fileFieldsConfigHash', () => {
+    test('to be fixed value', () => {
+      const expected = {}
+
+      const actual = BasePostRenderer.fileFieldsConfigHash
+
+      expect(actual)
+        .toEqual(expected)
+    })
+  })
+})

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -61,6 +61,99 @@ describe('BasePostRenderer', () => {
 })
 
 describe('BasePostRenderer', () => {
+  describe('.defineMulterUploaderMiddleware()', () => {
+    describe('should be return value of Multer#fields()', () => {
+      const cases = [
+        {
+          input: {
+            fileFieldsConfigHash: {
+              alpha: 1,
+            },
+          },
+          expected: {
+            fieldsArgs: [
+              { name: 'alpha', maxCount: 1 },
+            ],
+          },
+        },
+      ]
+
+      test.each(cases)('with $input.fileFieldsConfigHash', ({ input, expected }) => {
+        const multerUploaderTally = multer()
+        const noneHandlerTally = () => {}
+        const fieldsHandlerTally = () => {}
+
+        const createMulterUploaderSpy = jest.spyOn(BasePostRenderer, 'createMulterUploader')
+          .mockReturnValue(multerUploaderTally)
+
+        jest.spyOn(BasePostRenderer, 'fileFieldsConfigHash', 'get')
+          .mockReturnValue(input.fileFieldsConfigHash)
+
+        const noneSpy = jest.spyOn(multerUploaderTally, 'none')
+          .mockReturnValue(noneHandlerTally)
+        const fieldsSpy = jest.spyOn(multerUploaderTally, 'fields')
+          .mockReturnValue(fieldsHandlerTally)
+
+        const actual = BasePostRenderer.defineMulterUploaderMiddleware()
+
+        expect(actual)
+          .toBe(fieldsHandlerTally) // same reference
+
+        expect(createMulterUploaderSpy)
+          .toHaveBeenCalledWith()
+
+        expect(noneSpy)
+          .not
+          .toHaveBeenCalledWith()
+        expect(fieldsSpy)
+          .toHaveBeenCalledWith(expected.fieldsArgs)
+      })
+    })
+
+    describe('should be return value of Multer#none()', () => {
+      const cases = [
+        {
+          input: {
+            fileFieldsConfigHash: {},
+          },
+        },
+      ]
+
+      test.each(cases)('with $input.fileFieldsConfigHash', ({ input }) => {
+        const multerUploaderTally = multer()
+        const noneHandlerTally = () => {}
+        const fieldsHandlerTally = () => {}
+
+        const createMulterUploaderSpy = jest.spyOn(BasePostRenderer, 'createMulterUploader')
+          .mockReturnValue(multerUploaderTally)
+
+        jest.spyOn(BasePostRenderer, 'fileFieldsConfigHash', 'get')
+          .mockReturnValue(input.fileFieldsConfigHash)
+
+        const noneSpy = jest.spyOn(multerUploaderTally, 'none')
+          .mockReturnValue(noneHandlerTally)
+        const fieldsSpy = jest.spyOn(multerUploaderTally, 'fields')
+          .mockReturnValue(fieldsHandlerTally)
+
+        const actual = BasePostRenderer.defineMulterUploaderMiddleware()
+
+        expect(actual)
+          .toBe(noneHandlerTally) // same reference
+
+        expect(createMulterUploaderSpy)
+          .toHaveBeenCalledWith()
+
+        expect(noneSpy)
+          .toHaveBeenCalledWith()
+        expect(fieldsSpy)
+          .not
+          .toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('BasePostRenderer', () => {
   describe('.createMulterUploader()', () => {
     test('should be an instance of Multer', () => {
       const multerUploaderTally = multer()

--- a/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
+++ b/tests/__tests__/server/restfulapi/renderers/BasePostRenderer.js
@@ -99,6 +99,58 @@ describe('BasePostRenderer', () => {
 })
 
 describe('BasePostRenderer', () => {
+  describe('.buildMulterUploaderFieldsInput()', () => {
+    describe('should return array of config', () => {
+      const cases = [
+        {
+          input: {
+            fileFieldsConfigHash: {
+              alpha: 1,
+            },
+          },
+          expected: [
+            { name: 'alpha', maxCount: 1 },
+          ],
+        },
+        {
+          input: {
+            fileFieldsConfigHash: {
+              avatar: 1,
+              gallery: 8,
+            },
+          },
+          expected: [
+            { name: 'avatar', maxCount: 1 },
+            { name: 'gallery', maxCount: 8 },
+          ],
+        },
+      ]
+
+      test.each(cases)('with $input.fileFieldsConfigHash', ({ input, expected }) => {
+        jest.spyOn(BasePostRenderer, 'fileFieldsConfigHash', 'get')
+          .mockReturnValue(input.fileFieldsConfigHash)
+
+        const actual = BasePostRenderer.buildMulterUploaderFieldsInput()
+
+        expect(actual)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should return empty array', () => {
+      test('with default definition of .get:fileFieldsConfigHash', () => {
+        const expected = []
+
+        const actual = BasePostRenderer.buildMulterUploaderFieldsInput()
+
+        expect(actual)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('BasePostRenderer', () => {
   describe('.get:fileFieldsConfigHash', () => {
     test('to be fixed value', () => {
       const expected = {}


### PR DESCRIPTION
# Why

* Close #498

# How

* All commits have already been reviewed, merge only
