### PR TITLE
💪 Update `RestfulApiRoutesBuilder#generateRenderInput()` with `#buildFulfilledRequestBody()`

### DIFF
--- a/lib/server/restfulapi/RestfulApiRoutesBuilder.js
+++ b/lib/server/restfulapi/RestfulApiRoutesBuilder.js
@@ -339,6 +339,10 @@ export default class RestfulApiRoutesBuilder {
     expressRequest,
     contextFactory,
   }) {
+    const body = this.buildFulfilledRequestBody({
+      expressRequest,
+    })
+
     const context = await contextFactory({
       expressRequest,
       engine: this.engine,
@@ -349,7 +353,7 @@ export default class RestfulApiRoutesBuilder {
     })
 
     return {
-      body: expressRequest.body,
+      body,
       query: expressRequest.query,
       context,
       request,

--- a/lib/server/restfulapi/RestfulApiRoutesBuilder.js
+++ b/lib/server/restfulapi/RestfulApiRoutesBuilder.js
@@ -339,13 +339,13 @@ export default class RestfulApiRoutesBuilder {
     expressRequest,
     contextFactory,
   }) {
-    const request = this.createRestfulApiRequest({
-      expressRequest,
-    })
-
     const context = await contextFactory({
       expressRequest,
       engine: this.engine,
+    })
+
+    const request = this.createRestfulApiRequest({
+      expressRequest,
     })
 
     return {

--- a/tests/__tests__/server/restfulapi/RestfulApiRoutesBuilder.js
+++ b/tests/__tests__/server/restfulapi/RestfulApiRoutesBuilder.js
@@ -1438,43 +1438,239 @@ describe('RestfulApiRoutesBuilder', () => {
       },
     ]
 
-    test.each(engineCases)('Engine: $params.Engine.name', async ({ params }) => {
-      const engine = await params.Engine.createAsync()
-
-      /** @type {ExpressType.Request} */
-      const expressMock = /** @type {*} */ ({
-        body: {
-          tally: Symbol('get tally'),
-        },
-        query: {
-          tally: Symbol('post tally'),
-        },
-        params: {},
+    describe.each(engineCases)('Engine: $params.Engine.name', ({ params }) => {
+      /** @type {Express.Multer.File} */
+      const alphaFile = /** @type {*} */ ({
+        tally: Symbol('alpha file'),
       })
 
-      const builder = await RestfulApiRoutesBuilder.createAsync({
-        engine,
+      /** @type {Express.Multer.File} */
+      const betaFile = /** @type {*} */ ({
+        tally: Symbol('beta file'),
       })
 
-      const contextFactoryMock = async () => params.Context.createAsync({
-        expressRequest: expressMock,
-        engine,
+      /** @type {Express.Multer.File} */
+      const gammaFile = /** @type {*} */ ({
+        tally: Symbol('gamma file'),
       })
 
-      const expected = {
-        body: expressMock.body,
-        query: expressMock.query,
-        context: expect.any(params.Context),
-        request: expect.any(RestfulApiRequest),
-      }
-
-      const actual = await builder.generateRenderInput({
-        expressRequest: expressMock,
-        contextFactory: contextFactoryMock,
+      /** @type {Express.Multer.File} */
+      const deltaFile = /** @type {*} */ ({
+        tally: Symbol('delta file'),
       })
 
-      expect(actual)
-        .toEqual(expected)
+      describe('with Express request files', () => {
+        /**
+         * @type {Array<{
+         *   expressRequest: ExpressType.Request
+         *   expected: Record<string, any>
+         * }>}
+         */
+        const cases = /** @type {Array<*>} */ ([
+          {
+            expressRequest: {
+              body: {
+                first: 'first value',
+                second: 'second value',
+              },
+              query: {
+                tally: Symbol.for('first query tally'),
+              },
+              params: {},
+              files: {
+                alpha: [
+                  alphaFile,
+                ],
+              },
+            },
+            expected: {
+              body: {
+                first: 'first value',
+                second: 'second value',
+                alpha: [
+                  alphaFile,
+                ],
+              },
+              query: {
+                tally: Symbol.for('first query tally'),
+              },
+              context: expect.any(params.Context),
+              request: expect.any(RestfulApiRequest),
+            },
+          },
+          {
+            expressRequest: {
+              body: {
+                third: 'third value',
+                fourth: 'fourth value',
+              },
+              query: {
+                tally: Symbol.for('second query tally'),
+              },
+              params: {},
+              files: {
+                beta: [
+                  betaFile,
+                  gammaFile,
+                ],
+              },
+            },
+            expected: {
+              body: {
+                third: 'third value',
+                fourth: 'fourth value',
+                beta: [
+                  betaFile,
+                  gammaFile,
+                ],
+              },
+              query: {
+                tally: Symbol.for('second query tally'),
+              },
+              context: expect.any(params.Context),
+              request: expect.any(RestfulApiRequest),
+            },
+          },
+          {
+            expressRequest: {
+              body: {
+                fifth: 'fifth value',
+                sixth: 'sixth value',
+              },
+              query: {
+                tally: Symbol.for('third query tally'),
+              },
+              params: {},
+              files: {
+                alpha: [
+                  betaFile,
+                ],
+                beta: [
+                  gammaFile,
+                  deltaFile,
+                ],
+              },
+            },
+            expected: {
+              body: {
+                fifth: 'fifth value',
+                sixth: 'sixth value',
+                alpha: [
+                  betaFile,
+                ],
+                beta: [
+                  gammaFile,
+                  deltaFile,
+                ],
+              },
+              query: {
+                tally: Symbol.for('third query tally'),
+              },
+              context: expect.any(params.Context),
+              request: expect.any(RestfulApiRequest),
+            },
+          },
+        ])
+
+        test.each(cases)('body: $expressRequest.body', async ({ expressRequest, expected }) => {
+          const engine = await params.Engine.createAsync()
+
+          const builder = await RestfulApiRoutesBuilder.createAsync({
+            engine,
+          })
+
+          const contextFactory = async () => params.Context.createAsync({
+            expressRequest,
+            engine,
+          })
+
+          const actual = await builder.generateRenderInput({
+            expressRequest,
+            contextFactory,
+          })
+
+          expect(actual)
+            .toEqual(expected)
+        })
+      })
+
+      describe('without Express request files', () => {
+        /**
+         * @type {Array<{
+         *   expressRequest: ExpressType.Request
+         *   expected: Record<string, any>
+         * }>}
+         */
+        const cases = /** @type {Array<*>} */ ([
+          {
+            expressRequest: {
+              body: {
+                first: 'first value',
+                second: 'second value',
+              },
+              query: {
+                tally: Symbol.for('first query tally'),
+              },
+              params: {},
+            },
+            expected: {
+              body: {
+                first: 'first value',
+                second: 'second value',
+              },
+              query: {
+                tally: Symbol.for('first query tally'),
+              },
+              context: expect.any(params.Context),
+              request: expect.any(RestfulApiRequest),
+            },
+          },
+          {
+            expressRequest: {
+              body: {
+                third: 'third value',
+                fourth: 'fourth value',
+              },
+              query: {
+                tally: Symbol.for('second query tally'),
+              },
+              params: {},
+            },
+            expected: {
+              body: {
+                third: 'third value',
+                fourth: 'fourth value',
+              },
+              query: {
+                tally: Symbol.for('second query tally'),
+              },
+              context: expect.any(params.Context),
+              request: expect.any(RestfulApiRequest),
+            },
+          },
+        ])
+
+        test.each(cases)('body: $expressRequest.body', async ({ expressRequest, expected }) => {
+          const engine = await params.Engine.createAsync()
+
+          const builder = await RestfulApiRoutesBuilder.createAsync({
+            engine,
+          })
+
+          const contextFactory = async () => params.Context.createAsync({
+            expressRequest,
+            engine,
+          })
+
+          const actual = await builder.generateRenderInput({
+            expressRequest,
+            contextFactory,
+          })
+
+          expect(actual)
+            .toEqual(expected)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
# Why

* Close #528
