### PR TITLE
💪 Retake `TopicReceiver#generateAsyncIteratorReturn()` using `null` instead of `undefined`

### DIFF
--- a/lib/server/graphql/subscription/TopicReceiver.js
+++ b/lib/server/graphql/subscription/TopicReceiver.js
@@ -161,7 +161,7 @@ export default class TopicReceiver {
       await this.unsubscribe()
 
       return {
-        value: undefined,
+        value: null,
         done: true,
       }
     }

--- a/tests/__tests__/server/graphql/subscription/TopicReceiver.js
+++ b/tests/__tests__/server/graphql/subscription/TopicReceiver.js
@@ -789,7 +789,7 @@ describe('TopicReceiver', () => {
         const generatedReturnFunction = receiver.generateAsyncIteratorReturn()
 
         const expected = {
-          value: undefined,
+          value: null,
           done: true,
         }
 


### PR DESCRIPTION
# Why

* Close #552