### PR TITLE
🧵 Fix lint error of `jsdoc/require-jsdoc` rule in `CustomerGraphqlShare`

### DIFF
--- a/app/server/graphql/contexts/CustomerGraphqlShare.js
+++ b/app/server/graphql/contexts/CustomerGraphqlShare.js
@@ -9,6 +9,14 @@ import AiResponseRedisClerk from '../../../client/redis/AiResponseRedisClerk.js'
  * please refer to this ExtraClient in this sample code.
  */
 const ExtraClient = class {
+  /**
+   * Factory method to create an instance of ExtraClient.
+   *
+   * @param {{
+   *   config: object
+   * }} params - Parameters of this method.
+   * @returns {ExtraClient} - An instance of ExtraClient.
+   */
   static create ({
     config,
   }) {


### PR DESCRIPTION
# Why

* Close #558