### PR TITLE
🦵 Kick out unnecessary variable from test for `RestfulApiResponse.create()`

### DIFF
--- a/tests/__tests__/server/restfulapi/interfaces/RestfulApiResponse.js
+++ b/tests/__tests__/server/restfulapi/interfaces/RestfulApiResponse.js
@@ -635,7 +635,7 @@ describe('RestfulApiResponse', () => {
           },
         ]
 
-        test.each(cases)('$#', ({ params, expected }) => {
+        test.each(cases)('$#', ({ params }) => {
           const SpyClass = globalThis.constructorSpy.spyOn(RestfulApiResponse)
 
           expect(() => SpyClass.create(params))


### PR DESCRIPTION
# Why

* Close #584