### PR TITLE
🚧 Enhance `RedisPubSub.create()` using instance of `Redis`

### DIFF
--- a/lib/server/graphql/subscription/pubsub/RedisPubSub.js
+++ b/lib/server/graphql/subscription/pubsub/RedisPubSub.js
@@ -39,18 +39,22 @@ export default class RedisPubSub extends BasePubSub {
       host: 'localhost',
       port: 6379,
     },
+    publishingRedisClient = null,
+    subscribingRedisClient = null,
   } = {}) {
-    const publishingRedisClient = this.createRedis({
+    const resolvedPublishingRedisClient = this.resolveRedisClient({
       options,
+      redisClient: publishingRedisClient,
     })
-    const subscribingRedisClient = this.createRedis({
+    const resolvedSubscribingRedisClient = this.resolveRedisClient({
       options,
+      redisClient: subscribingRedisClient,
     })
 
     return /** @type {InstanceType<T>} */ (
       new this({
-        publishingRedisClient,
-        subscribingRedisClient,
+        publishingRedisClient: resolvedPublishingRedisClient,
+        subscribingRedisClient: resolvedSubscribingRedisClient,
       })
     )
   }
@@ -176,5 +180,7 @@ export default class RedisPubSub extends BasePubSub {
 /**
  * @typedef {{
  *   options?: import('ioredis').RedisOptions
+ *   publishingRedisClient?: Redis | null
+ *   subscribingRedisClient?: Redis | null
  * }} RedisPubSubFactoryParams
  */


### PR DESCRIPTION
# Why

* Close #596 

# How

* 

<!--
* All commits have already been reviewed, merge only
-->
