### PR TITLE
⚙️ Switch `runs-on:` by repository visibility

### DIFF
--- a/.github/workflows/fill-publish-version.yml
+++ b/.github/workflows/fill-publish-version.yml
@@ -18,7 +18,9 @@ jobs:
   fill:
     if: startsWith(github.event.issue.title, '🚀 Publish')
 
-    runs-on: ubuntu-latest
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
 
     steps:
       - name: 🤖 Replace vvvvvv with the version in the title

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -16,7 +16,9 @@ jobs:
   main-guard:
     name: Main Guard
 
-    runs-on: ubuntu-latest
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
 
     timeout-minutes: 5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ jobs:
     # Only run when PR is merged
     if: github.event.pull_request.merged == true
 
-    runs-on: ubuntu-latest
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
 
     steps:
       - name: 🛎 Checkout code

--- a/.github/workflows/test-with-db-as-development.yml
+++ b/.github/workflows/test-with-db-as-development.yml
@@ -40,10 +40,14 @@ jobs:
           node-version: lts/*
           registry-url: https://npm.pkg.github.com
 
-      - name: 🖨️ Print runtime versions
+      - name: 🖨️ Print environment
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
-          node -v
-          npm -v
+          echo
+          echo "runner: $RUNNER_ENVIRONMENT"
+          echo "node:   $(node -v)"
+          echo "npm:    $(npm -v)"
 
       - name: 📦 Install packages
         run: npm ci

--- a/.github/workflows/test-with-db-as-development.yml
+++ b/.github/workflows/test-with-db-as-development.yml
@@ -19,7 +19,9 @@ jobs:
     # from the merge gate.
     name: CI Test
 
-    runs-on: ubuntu-latest
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
 
     timeout-minutes: 60
 

--- a/.github/workflows/test-with-db-as-live.yml
+++ b/.github/workflows/test-with-db-as-live.yml
@@ -62,10 +62,14 @@ jobs:
           node-version: lts/*
           registry-url: https://npm.pkg.github.com
 
-      - name: 🖨️ Print runtime versions
+      - name: 🖨️ Print environment
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
-          node -v
-          npm -v
+          echo
+          echo "runner: $RUNNER_ENVIRONMENT"
+          echo "node:   $(node -v)"
+          echo "npm:    $(npm -v)"
 
       - name: 📦 Install packages
         run: npm ci

--- a/.github/workflows/test-with-db-as-live.yml
+++ b/.github/workflows/test-with-db-as-live.yml
@@ -19,7 +19,9 @@ jobs:
     # from the merge gate.
     name: CI Test
 
-    runs-on: ubuntu-latest
+    # private repository: self-hosted
+    # public repository: github-hosted
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted", "light"]' || '["ubuntu-latest"]') }}
 
     timeout-minutes: 60
 


### PR DESCRIPTION
# Why

* Close #643 

# How

* Pick the runner from `github.event.repository.private` in all five workflows, so a private clone
  runs on `[self-hosted, light]` and the public one on `ubuntu-latest`
* Rename the version-printing step to `🖨️ Print environment` and add `runner.environment`, so the
  log records which runner the switch resolved to

<!--
* `runner.environment` is unusable in `runs-on` itself: the runner is not assigned yet, so the
  `runner` context is empty and the expression would always fall through to `ubuntu-latest`.
* Follow-up items are listed in the issue, not handled here.
-->