### PR TITLE
📄 Fix the copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Open Reach Tech Inc.
+   Copyright 2024 Open Reach Tech Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Apache-2.0 LICENSE merged in #636 carries `Copyright 2026`, which came along with the
license text copied from another repository.

The year states when the work was first opened as OSS. This repository has been open source since
2024, and the README copyright section says `© 2024`, so the LICENSE goes back to 2024.

Close #647