### PR TITLE
📄 Fix the copyright notation in LICENSE and the README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Open Reach Tech Inc.
+   Copyright 2024 Open Reach Tech Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.ja.md
+++ b/README.ja.md
@@ -177,7 +177,7 @@ npm test
 
 ## 開発者
 
-[Open Reach Tech inc.](https://openreach.tech)
+[Open Reach Tech Inc.](https://openreach.tech)
 
 ## 著作権
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ npm test
 
 ## Developers
 
-[Open Reach Tech inc.](https://openreach.tech)
+[Open Reach Tech Inc.](https://openreach.tech)
 
 ## Copyright
 


### PR DESCRIPTION
Two copyright-notice fixes.

- `LICENSE`: `Copyright 2026` → `Copyright 2024`. The 2026 came along with the Apache-2.0 text
  copied from another repository in #636. The year states when the work was first opened as OSS, and
  this repository has been open source since 2024, as the README copyright section says.
- `README.md` / `README.ja.md`: `Open Reach Tech inc.` → `Open Reach Tech Inc.`

The README copyright year is left untouched. #640 changed it and was closed for that reason.

Close #649