### PR TITLE
📄 Update the license field to Apache-2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@openreachtech/renchan",
       "version": "2.9.1",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.6",
         "@graphql-tools/utils": "^10.5.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "Renchan"
   ],
   "author": "Open Reach Tech Inc.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/openreachtech/renchan-core/issues"
   },


### PR DESCRIPTION
`LICENSE` became Apache-2.0 in #636, while the `license` field stayed `MIT` in
`package.json` and in the root entry of `package-lock.json`. Both now read `Apache-2.0`.

The field ships inside the published tarball, so it has to agree with the LICENSE file before
publishing to npmjs.

Close #661