### PR TITLE
📦️ Update `renchan-env` to `1.0.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@graphql-tools/schema": "^10.0.6",
         "@graphql-tools/utils": "^10.5.5",
-        "@openreachtech/renchan-env": "^1.0.2",
+        "@openreachtech/renchan-env": "^1.0.5",
         "bignumber.js": "^9.1.1",
         "cors": "^2.8.5",
         "express": "^4.21.1",
@@ -3169,10 +3169,10 @@
       "license": "MIT"
     },
     "node_modules/@openreachtech/renchan-env": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@openreachtech/renchan-env/-/renchan-env-1.0.4.tgz",
-      "integrity": "sha512-I8gyq837/4cpAKWJXFVAj8UQrdz9fZvt82KMOqR/SyWia9yPN4y+keRxE8ZFNYAfg+fnrAh1+M98AW6nyG7sfw==",
-      "license": "MIT",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@openreachtech/renchan-env/-/renchan-env-1.0.5.tgz",
+      "integrity": "sha512-euQ/ncytWaAPHyxVvJzUDoPZr0rNTuEjEcArKU6QyJAmXs2o5qbAb8DllxAdhG53XZGeUFWN7PsWWjf1sCrkYA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.6.1"
       }
@@ -13452,9 +13452,9 @@
       "dev": true
     },
     "@openreachtech/renchan-env": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@openreachtech/renchan-env/-/renchan-env-1.0.4.tgz",
-      "integrity": "sha512-I8gyq837/4cpAKWJXFVAj8UQrdz9fZvt82KMOqR/SyWia9yPN4y+keRxE8ZFNYAfg+fnrAh1+M98AW6nyG7sfw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@openreachtech/renchan-env/-/renchan-env-1.0.5.tgz",
+      "integrity": "sha512-euQ/ncytWaAPHyxVvJzUDoPZr0rNTuEjEcArKU6QyJAmXs2o5qbAb8DllxAdhG53XZGeUFWN7PsWWjf1sCrkYA==",
       "requires": {
         "dotenv": "^16.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@graphql-tools/schema": "^10.0.6",
     "@graphql-tools/utils": "^10.5.5",
-    "@openreachtech/renchan-env": "^1.0.2",
+    "@openreachtech/renchan-env": "^1.0.5",
     "bignumber.js": "^9.1.1",
     "cors": "^2.8.5",
     "express": "^4.21.1",


### PR DESCRIPTION
`@openreachtech/renchan-env` is the only runtime dependency of this package. npmjs now carries
`1.0.5`, the Apache-2.0 relicense, while the lockfile pinned `1.0.4` (MIT).

The dependency range ships inside the published tarball, so it moves before publishing to npmjs.

Close #667