### PR TITLE
⚙️ Update package version to `2.9.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/renchan",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/renchan",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/renchan",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Renchan Core module for Application.",
   "files": [
     "lib/",


### PR DESCRIPTION
The release branch is `release/2.9.2`, so `package.json` and the two version fields of
`package-lock.json` move from `2.9.1` to `2.9.2` before publishing to npmjs.

Close #670